### PR TITLE
change command for Windows, grunt.cmd

### DIFF
--- a/grunt-build-on-save.py
+++ b/grunt-build-on-save.py
@@ -9,7 +9,11 @@ class BuildGruntOnSave(sublime_plugin.EventListener):
 
     #let's see if project wants to be autobuilt.
     should_build = view.settings().get('build_on_save')
+
     if should_build == 1:
-      view.window().run_command('exec',{'cmd':['grunt'],'working_dir':folder})
+      if sublime.platform() == 'windows':
+        view.window().run_command('exec',{'cmd':['grunt.cmd', "--no-color"],'working_dir':folder})
+      else:
+        view.window().run_command('exec',{'cmd':['grunt', "--no-color"],'working_dir':folder})
     else:
       print 'BuildGruntOnSave: Project not configured for build_on_save.  Try setting build_on_save in project settings'

--- a/grunt.sublime-build
+++ b/grunt.sublime-build
@@ -5,7 +5,7 @@
   "selector": "Gruntfile.js",
   "windows":
   {
-    "cmd": ["grunt", "--no-color"]
+    "cmd": ["grunt.cmd", "--no-color"]
   },
   "variants":
   [
@@ -14,7 +14,7 @@
       "cmd": ["grunt", "--no-color"],
       "windows":
       {
-        "cmd": ["grunt", "--no-color"]
+        "cmd": ["grunt.cmd", "--no-color"]
       }
     }
   ]


### PR DESCRIPTION
On Windows, it has to be grunt.cmd instead of grunt in cmd property due to a known error on Windows.
